### PR TITLE
Use a real ffmpeg image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This may be leveraged with the [IOpipe library](https://github.com/iopipe/iopipe
 to chain execution with local functions, remote functions,
 and APIs.
 
+Utilizes the minimal, Alpine-linux based [ffmpeg image from
+sjourdan](https://github.com/sjourdan/ffmpeg-docker).
+
 ```javascript
 var iopipe = require("iopipe")()
 var Dockaless = require("dockaless")
@@ -33,7 +36,7 @@ var dals = new Dockaless()
 exports.handler = iopipe.define(
   iopipe.property("url"),
   iopipe.fetch,
-  dals.make_lambda("ffmpeg", [ "-i", "pipe:0", "-vf", "scale=320:240", "pipe:1" ])
+  dals.make_lambda("sjourdan/ffmpeg", [ "-i", "pipe:0", "-vf", "scale=320:240", "pipe:1" ])
 )
 ```
 
@@ -76,7 +79,7 @@ exports.handler = iopipe.define(
   iopipe.property("urls"),
   iopipe.map(
     iopipe.fetch,
-    dals.make_lambda("ffmpeg", [ "-i", "pipe:0", "-vf", "scale=320:240", "pipe:1" ]),
+    dals.make_lambda("sjourdan/ffmpeg", [ "-i", "pipe:0", "-vf", "scale=320:240", "pipe:1" ]),
     (event, context) => {
       var video_hash = crypto.createHash('sha256').update(event).digest('hex')
       put_bucket({


### PR DESCRIPTION
Choose the sjourdan image which is exceptionally small
as it's based on Alpine Linux. It's also open source
and available here: https://github.com/sjourdan/ffmpeg-docker

Signed-off-by: Eric Windisch eric@windisch.us
